### PR TITLE
Add support for anon channel restrictions

### DIFF
--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -1116,8 +1116,8 @@ class ChatMethods:
 
         user = await self.get_input_entity(user)
         ty = helpers._entity_type(user)
-        if ty != helpers._EntityType.USER:
-            raise ValueError('You must pass a user entity')
+        if ty not in (helpers._EntityType.USER, helpers._EntityType.CHANNEL):
+            raise ValueError('You must pass a user or channel entity')
 
         if isinstance(user, types.InputPeerSelf):
             raise ValueError('You cannot restrict yourself')


### PR DESCRIPTION
Telethon doesn't currently support banning anon channels from groups while anonymous channels can be a real pita sometimes and do spam heavily.